### PR TITLE
chore(deps): bump flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778794387,
-        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "lastModified": 1781454065,
+        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778815121,
-        "narHash": "sha256-xlhD+1NVJbhrUUM2usRHW6iKWTXP2uw2Fo6sWJmLg8g=",
+        "lastModified": 1781493707,
+        "narHash": "sha256-lzf7qdQWuiY0T9VEbfH2CmP1LZQAYooU/sZuSgEJEBk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "017351829a9356423afd2cca0dde9b63346c8ab3",
+        "rev": "06f25b8e40805beb2121a4dae4cc37d6f981800f",
         "type": "github"
       },
       "original": {

--- a/pkgs/gemini-cli-bin/default.nix
+++ b/pkgs/gemini-cli-bin/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   ripgrep,
-  nodejs_20,
   fetchurl,
   buildNpmPackage,
   fetchNpmDeps,
@@ -37,8 +36,6 @@ buildNpmPackage (finallAttrs: {
   dontNpmBuild = true;
 
   npmFlags = [ "--ignore-scripts" ];
-
-  nodejs = nodejs_20;
 
   postInstall = ''
     mkdir -p $out/lib/node_modules/${pname}/node_modules/@lvce-editor/ripgrep/bin


### PR DESCRIPTION
🔄 Updating 2 inputs (excluding: lix, lix-module)

✨ Update details:
- nixpkgs: 0iMM%3D → VAXw%3D
- rust-overlay: Lg8g%3D → JEBk%3D